### PR TITLE
gi-docgen 2025.5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   entry_points:
     - gi-docgen=gidocgen.gidocmain:main
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
-  skip: True  # [py<37]
+  skip: True  # [py<36]
 
 requirements:
   host:
@@ -22,33 +22,39 @@ requirements:
     - setuptools
     - wheel
     - python
-    - markdown
+    - markdown >=3.2
     - markupsafe
     - pygments
     - typogrify
     - jinja2
-    - toml
+    - packaging
+    - tomli >=1,<3  # [py<311]
   run:
     - python
-    - markdown
+    - markdown >=3.2
     - markupsafe
     - pygments
     - typogrify
     - jinja2
-    - toml
     - packaging
+    - tomli >=1,<3  # [py<311]
 
 test:
   imports:
     - gidocgen
     - gidocgen.gir
     - gidocgen.core
+    - gidocgen.gidocmain
   requires:
     - pip
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - gi-docgen --help
+    - test -f $PREFIX/share/pkgconfig/gi-docgen.pc  # [unix]
+    - test -f $PREFIX/share/man/man1/gi-docgen.1    # [unix]
+    - if not exist "%PREFIX%\\share\\pkgconfig\\gi-docgen.pc" exit /b 1  # [win]
+    - if not exist "%PREFIX%\\share\\man\\man1\\gi-docgen.1" exit /b 1   # [win]
 
 about:
   home: https://gitlab.gnome.org/GNOME/gi-docgen

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,15 +20,7 @@ requirements:
   host:
     - pip
     - setuptools
-    - wheel
     - python
-    - markdown >=3.2
-    - markupsafe
-    - pygments
-    - typogrify
-    - jinja2
-    - packaging
-    - tomli >=1,<3  # [py<311]
   run:
     - python
     - markdown >=3.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,19 @@
 {% set name = "gi-docgen" %}
-{% set version = "2022.1" %}
+{% set version = "2025.5" %}
 
 package:
   name: "{{ name|lower }}"
   version: "{{ version }}"
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: f91d879ff28d7d5265cde84275ee510e32386bfeb7ec6203a647342aead55cec
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: 7fb2b5370d99849e52e74e9e584b7eeb5b5a3a95493d6752c88c0d251777f4bf
 
 build:
   number: 0
   entry_points:
     - gi-docgen=gidocgen.gidocmain:main
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   skip: True  # [py<37]
 
 requirements:
@@ -36,12 +36,18 @@ requirements:
     - typogrify
     - jinja2
     - toml
+    - packaging
 
 test:
   imports:
     - gidocgen
     - gidocgen.gir
+    - gidocgen.core
+  requires:
+    - pip
   commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - gi-docgen --help
 
 about:


### PR DESCRIPTION
gi-docgen 2025.5

**Destination channel:** {defaults}

### Links

- [[PKG-12044](https://anaconda.atlassian.net/browse/PKG-11097)]
- dev_url:        https://gitlab.gnome.org/GNOME/gi-docgen/tree/2025.5
- conda_forge:    https://github.com/conda-forge/gi-docgen-feedstock
- pypi:           https://pypi.org/project/gi-docgen/2025.5
- pypi inspector: https://inspector.pypi.io/project/gi-docgen/2025.5

### Explanation of changes:

- version updated 2022.1 → 2025.5
- added ANACONDA_ROCKET_ENABLE_PY314 to abs.yaml
- update host/run requirements (markdown, toml, packaging, tomli)
- tests pkgconfig/man file checks on unix/windows

[PKG-12044]: https://anaconda.atlassian.net/browse/PKG-12044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ